### PR TITLE
New command line options

### DIFF
--- a/bin/csv2json
+++ b/bin/csv2json
@@ -6,7 +6,7 @@ require 'ostruct'
 require File.join(File.expand_path(File.dirname(__FILE__)), '..', 'lib', 'csv2json.rb') # this form is important for local development
 
 module CSV2JSONRunner
-    
+
     # command-line parsing
     COMMAND = File.basename($0)
     USAGE = "Usage: #{COMMAND} [INPUT] [OPTIONS]"
@@ -14,6 +14,7 @@ module CSV2JSONRunner
     options = OpenStruct.new
     options.output = "-"
     options.separator = ","
+    options.pretty = false
 
     opts = OptionParser.new do |o|
         o.banner = USAGE
@@ -26,6 +27,10 @@ module CSV2JSONRunner
 
         o.on("-o", "--output FILE", "Write output to a file") do |fn|
             options.output = fn
+        end
+
+        o.on("-p", "--pretty", "Pretty-format JSON output") do 
+            options.pretty = true
         end
 
         o.on_tail("-h", "--help", "Show this message") do
@@ -59,7 +64,7 @@ module CSV2JSONRunner
     end
     
     # run the command
-    CSV2JSON.parse(IN, OUT, nil, :col_sep => options.separator)
+    CSV2JSON.parse(IN, OUT, nil, {:col_sep => options.separator}, {:pretty => options.pretty})
     
     # leave in peace
     OUT.flush

--- a/bin/csv2json
+++ b/bin/csv2json
@@ -15,6 +15,8 @@ module CSV2JSONRunner
     options.output = "-"
     options.separator = ","
     options.pretty = false
+    options.headers = nil
+    options.skipFirstRow = false
 
     opts = OptionParser.new do |o|
         o.banner = USAGE
@@ -31,6 +33,19 @@ module CSV2JSONRunner
 
         o.on("-p", "--pretty", "Pretty-format JSON output") do 
             options.pretty = true
+        end
+
+        o.on("-H", "--force-headers HEADERS", "Supply list of headers, and skip first row of input; use to override headers in file") do |headers|
+            if headers then
+                options.headers = headers.split(",")
+                options.skipFirstRow = true
+            end
+        end
+
+        o.on("-h", "--headers HEADERS", "Supply list of headers, where no headers exist in the file") do |headers|
+            if headers then
+                options.headers = headers.split(",")
+            end
         end
 
         o.on_tail("-h", "--help", "Show this message") do
@@ -64,7 +79,7 @@ module CSV2JSONRunner
     end
     
     # run the command
-    CSV2JSON.parse(IN, OUT, nil, {:col_sep => options.separator}, {:pretty => options.pretty})
+    CSV2JSON.parse(IN, OUT, options.headers, {:col_sep => options.separator}, {:pretty => options.pretty, :skipFirstRow => options.skipFirstRow})
     
     # leave in peace
     OUT.flush

--- a/lib/csv2json.rb
+++ b/lib/csv2json.rb
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'fastercsv'
 require 'json'
 require 'csv2json-version.rb'
@@ -11,10 +12,10 @@ module CSV2JSON
     end
 
     # input and output are file objects, you can use StringIO if you want to work in memory
-    def parse(input, output, headers=nil, options={})
+    def parse(input, output, headers=nil, csvOptions={}, gemOptions={})
         result = Array.new
 
-        FasterCSV.new(input, options).each do |row|
+        FasterCSV.new(input, csvOptions).each do |row|
             # treat first row as headers if the caller didn't provide them
             unless headers 
                 headers = row
@@ -27,7 +28,12 @@ module CSV2JSON
             result << snippet
         end
         
-        output << JSON.pretty_generate(result)
+        if gemOptions[:pretty] == true then
+            output << JSON.pretty_generate(result)
+        else
+            output << JSON.generate(result)
+        end
+
     end
     
     module_function :parse

--- a/lib/csv2json.rb
+++ b/lib/csv2json.rb
@@ -21,6 +21,11 @@ module CSV2JSON
                 headers = row
                 next
             end
+
+            if gemOptions[:skipFirstRow] then
+                gemOptions[:skipFirstRow] = false
+                next
+            end
             
             # build JSON snippet and append it to the result
             snippet = Hash.new


### PR DESCRIPTION
I've switched off pretty formatting by default (as single-line is easier to handle when redirecting output on the command line) and added a "-p" option to enable it selectively.

Also, have introduced 2 new options, "-h" and -H", to allow control of headers from the command line (as this wasn't plumbed all the way through before).
"-h" allows basic provision of headers, in the situation where the file doesn't contain them.
"-H" will force the headers to be those from the command-line, ignoring whatever is in the first line of the file completely. This allows us to use different element names in JSON than the originator of the CSV uses, without editing the file manually.
