### PR TITLE
Fixes orderedhash not found dependency problem.

### DIFF
--- a/csv2json.gemspec
+++ b/csv2json.gemspec
@@ -60,13 +60,16 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<json>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
+      s.add_development_dependency(%q<orderedhash>, [">= 0"])
     else
       s.add_dependency(%q<json>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
+      s.add_dependency(%q<orderedhash>, [">= 0"])
     end
   else
     s.add_dependency(%q<json>, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
+    s.add_dependency(%q<orderedhash>, [">= 0"])
   end
 end
 


### PR DESCRIPTION
When trying to use csv2json, it unfortunately does not work out of the box. It depends on a gem that is not installed by default. This is a very frustrating situation.
#15 is not only restricted to Ubuntu. It is a missing requirement in the Gemfile.

Closes #15 
